### PR TITLE
Correct misspelling of 'automatically' in OS X Installer

### DIFF
--- a/resources_osx/welcome.html
+++ b/resources_osx/welcome.html
@@ -9,6 +9,6 @@
     <p style="font-size: 105%;">You will be guided through the steps necessary to install this software. This installer includes the Pritunl Client app, helper service required for creating OpenVPN connections and the OpenVPN tun/tap extensions needed for virtual network interfaces.</p>
 
     <h2 style="font-size: 110%;">Uninstallation</h2>
-    <p style="font-size: 105%;">All files and services may be uninstalled by first closing the client app and dragging the Pritunl app from your applications to the trash. After the app is removed, the helper service will detect that the client app is no longer installed. The helper service will then automaitcally remove itself along with all other installed files and all vpn profiles. If you wish to keep the vpn profiles, they will need to be copied from the Application Support directory.</p>
+    <p style="font-size: 105%;">All files and services may be uninstalled by first closing the client app and dragging the Pritunl app from your applications to the trash. After the app is removed, the helper service will detect that the client app is no longer installed. The helper service will then automatically remove itself along with all other installed files and all vpn profiles. If you wish to keep the vpn profiles, they will need to be copied from the Application Support directory.</p>
   </body>
 </html>


### PR DESCRIPTION
Small typo in the OS X installer's welcome resource.