### PR TITLE
stop service on quit

### DIFF
--- a/client/www/main.js
+++ b/client/www/main.js
@@ -118,6 +118,16 @@ app.on('activate', function() {
   openMainWin();
 });
 
+app.on('quit', function() {
+  request.post({
+    url: 'http://' + constants.serviceHost + '/stop',
+    headers: {
+      'Auth-Key': constants.key
+    }
+  });
+});
+
+
 var openMainWin = function() {
   if (main) {
     main.focus();
@@ -298,14 +308,7 @@ app.on('ready', function() {
           {
             label: 'Exit',
             click: function() {
-              request.post({
-                url: 'http://' + constants.serviceHost + '/stop',
-                headers: {
-                  'Auth-Key': constants.key
-                }
-              }, function() {
-                app.quit();
-              });
+              app.quit();
             }
           }
         ]


### PR DESCRIPTION
On mac, when you logout of one user account, pritunl quits but the service doesn't stop. That creates a problem if you log in into another user account and try to open pritunl. This commit stops the service on app-quit and thus solves the problem.