### PR TITLE
OpenVPN profile import failing on Windows

### DIFF
--- a/client/www/js/importer.js
+++ b/client/www/js/importer.js
@@ -123,7 +123,7 @@ Importer.prototype.read = function(pth, data, callback) {
         fs.readFile(filePth, 'utf8', function(err, data) {
           if (err) {
             err = new errors.ReadError(
-              'importer: Failed to read profile ca cert (%s)', err);
+              'importer: Failed to read profile user key (%s)', err);
             logger.error(err);
             return;
           }

--- a/client/www/js/importer.js
+++ b/client/www/js/importer.js
@@ -36,7 +36,7 @@ Importer.prototype.addPath = function(pth) {
 };
 
 Importer.prototype.read = function(pth, data, callback) {
-  data = data.replace('\r', '');
+  data = data.replace(/\r/g, '');
   var line;
   var lines = data.split('\n');
   var jsonFound = null;


### PR DESCRIPTION
Import an OpenVPN file which contains the following lines, making sure that the files ca.crt, user.crt, and user.key exist in the same directory:

```
client
ca ca.crt
cert user.crt
key user.key
dev tun
```
The following errors occur:
Failed to read profile ca cert (Error: ENOENT: no such file or directory, open 'C:\config\ca.crt')
Failed to read profile ca cert (Error: ENOENT: no such file or directory, open 'C:\config\user.key')
Failed to read profile user cert (Error: ENOENT: no such file or directory, open 'C:\config\user.crt')

This happens because importer only removes the first carriage return in the imported config file rather than all of them, so the file paths end up with a trailing carriage return.

Additionally the error message for the user key is incorrect and mentions 'ca cert' rather than 'user key'.