### PR TITLE
Add disable_ipv6 profile option to ignore server pushed IPv6 configuration

### DIFF
--- a/cli/sprofile/sprofile.go
+++ b/cli/sprofile/sprofile.go
@@ -35,6 +35,7 @@ type Sprofile struct {
 	DeviceAuth         bool                  `json:"device_auth"`
 	DisableGateway     bool                  `json:"disable_gateway"`
 	DisableDns         bool                  `json:"disable_dns"`
+	DisableIpv6        bool                  `json:"disable_ipv6"`
 	Dco                bool                  `json:"dco"`
 	DebugOutput        bool                  `json:"debug_output"`
 	RestrictClient     bool                  `json:"restrict_client"`

--- a/client/app/components/ProfileConnect.tsx
+++ b/client/app/components/ProfileConnect.tsx
@@ -273,6 +273,7 @@ export default class ProfileConnect extends React.Component<Props, State> {
 			device_auth: prfl.device_auth,
 			disable_gateway: prfl.disable_gateway,
 			disable_dns: prfl.disable_dns,
+			disable_ipv6: prfl.disable_ipv6,
 			dco: prfl.dco,
 			debug_output: prfl.debug_output,
 			force_dns: prfl.force_dns,

--- a/client/app/components/ProfileSettings.tsx
+++ b/client/app/components/ProfileSettings.tsx
@@ -348,6 +348,10 @@ export default class ProfileSettings extends React.Component<Props, State> {
 							value: profile.disable_dns,
 						},
 						{
+							label: 'Disable IPv6',
+							value: profile.disable_ipv6,
+						},
+						{
 							label: 'Data Channel Offload',
 							value: profile.dco,
 						},
@@ -485,6 +489,15 @@ export default class ProfileSettings extends React.Component<Props, State> {
 						checked={!!profile.disable_dns}
 						onToggle={(): void => {
 							this.set("disable_dns", !profile.disable_dns)
+						}}
+					/>
+					<PageSwitch
+						label="Disable IPv6"
+						help="Ignore the IPv6 configuration provided by the server on this profile. Use when the host has IPv6 disabled to prevent connection failures applying IPv6 addresses and routes."
+						hidden={profile.restrict_client}
+						checked={!!profile.disable_ipv6}
+						onToggle={(): void => {
+							this.set("disable_ipv6", !profile.disable_ipv6)
 						}}
 					/>
 					<PageSwitch

--- a/client/app/types/ProfileTypes.ts
+++ b/client/app/types/ProfileTypes.ts
@@ -50,6 +50,7 @@ export interface Profile {
 	device_auth?: boolean
 	disable_gateway?: boolean
 	disable_dns?: boolean
+	disable_ipv6?: boolean
 	dco?: boolean
 	debug_output?: boolean
 	force_dns?: boolean
@@ -154,6 +155,7 @@ export interface ProfileData {
 	device_auth?: boolean
 	disable_gateway?: boolean
 	disable_dns?: boolean
+	disable_ipv6?: boolean
 	dco?: boolean
 	debug_output?: boolean
 	restrict_client?: boolean
@@ -458,6 +460,7 @@ export function New(self: Profile): Profile {
 			disable_reconnect_local: this.disable_reconnect_local,
 			disable_gateway: this.disable_gateway,
 			disable_dns: this.disable_dns,
+			disable_ipv6: this.disable_ipv6,
 			dco: this.dco,
 			debug_output: this.debug_output,
 			force_dns: this.force_dns,
@@ -499,6 +502,7 @@ export function New(self: Profile): Profile {
 		this.disable_reconnect_local = data.disable_reconnect_local
 		this.disable_gateway = data.disable_gateway
 		this.disable_dns = data.disable_dns
+		this.disable_ipv6 = data.disable_ipv6
 		this.dco = data.dco
 		this.debug_output = data.debug_output
 		this.force_dns = data.force_dns
@@ -539,6 +543,7 @@ export function New(self: Profile): Profile {
 			device_auth: this.device_auth,
 			disable_gateway: this.disable_gateway,
 			disable_dns: this.disable_dns,
+			disable_ipv6: this.disable_ipv6,
 			dco: this.dco,
 			debug_output: this.debug_output,
 			force_dns: this.force_dns,
@@ -580,6 +585,7 @@ export function New(self: Profile): Profile {
 		this.disable_reconnect_local = data.disable_reconnect_local
 		this.disable_gateway = data.disable_gateway
 		this.disable_dns = data.disable_dns
+		this.disable_ipv6 = data.disable_ipv6
 		this.dco = data.dco
 		this.debug_output = data.debug_output
 		this.sso_auth = data.sso_auth

--- a/service/connection/ovpn.go
+++ b/service/connection/ovpn.go
@@ -198,6 +198,7 @@ func (o *Ovpn) Connect(data *ConnData) (err error) {
 		o.remotes,
 		o.conn.Profile.DisableGateway,
 		o.conn.Profile.DisableDns,
+		o.conn.Profile.DisableIpv6,
 		o.conn.Profile.Dco,
 		o.conn.Profile.DebugOutput,
 	)

--- a/service/connection/profile.go
+++ b/service/connection/profile.go
@@ -30,6 +30,7 @@ type Profile struct {
 	DeviceAuth         bool                        `json:"device_auth"`
 	DisableGateway     bool                        `json:"disable_gateway"`
 	DisableDns         bool                        `json:"disable_dns"`
+	DisableIpv6        bool                        `json:"disable_ipv6"`
 	Dco                bool                        `json:"dco"`
 	DebugOutput        bool                        `json:"debug_output"`
 	RestrictClient     bool                        `json:"restrict_client"`
@@ -52,6 +53,7 @@ func (p *Profile) Fields() logrus.Fields {
 		"profile_device_auth":      p.DeviceAuth,
 		"profile_disable_gateway":  p.DisableGateway,
 		"profile_disable_dns":      p.DisableDns,
+		"profile_disable_ipv6":     p.DisableIpv6,
 		"profile_dco":              p.Dco,
 		"profile_geo_sort":         p.IsGeoSort(),
 		"profile_force_connect":    p.ForceConnect,
@@ -126,6 +128,7 @@ func (p *Profile) ImportSystemProfile(sprfl *sprofile.Sprofile) {
 	p.DeviceAuth = sprfl.DeviceAuth
 	p.DisableGateway = sprfl.DisableGateway
 	p.DisableDns = sprfl.DisableDns
+	p.DisableIpv6 = sprfl.DisableIpv6
 	p.Dco = sprfl.Dco
 	p.DebugOutput = sprfl.DebugOutput
 	p.RestrictClient = sprfl.RestrictClient

--- a/service/connection/state.go
+++ b/service/connection/state.go
@@ -141,6 +141,7 @@ func (s *State) SetConnecting() {
 		"device_auth":      s.conn.Profile.DeviceAuth,
 		"disable_gateway":  s.conn.Profile.DisableGateway,
 		"disable_dns":      s.conn.Profile.DisableDns,
+		"disable_ipv6":     s.conn.Profile.DisableIpv6,
 		"dco":              s.conn.Profile.Dco,
 		"debug_output":     s.conn.Profile.DebugOutput,
 		"geo_sort":         s.conn.Profile.GeoSort,

--- a/service/handlers/profile.go
+++ b/service/handlers/profile.go
@@ -36,6 +36,7 @@ type profileData struct {
 	DeviceAuth         bool                        `json:"device_auth"`
 	DisableGateway     bool                        `json:"disable_gateway"`
 	DisableDns         bool                        `json:"disable_dns"`
+	DisableIpv6        bool                        `json:"disable_ipv6"`
 	Dco                bool                        `json:"dco"`
 	DebugOutput        bool                        `json:"debug_output"`
 	RestrictClient     bool                        `json:"restrict_client"`
@@ -130,6 +131,7 @@ func profilePost(c *gin.Context) {
 		DeviceAuth:         data.DeviceAuth,
 		DisableGateway:     data.DisableGateway,
 		DisableDns:         data.DisableDns,
+		DisableIpv6:        data.DisableIpv6,
 		Dco:                data.Dco,
 		DebugOutput:        data.DebugOutput,
 		RestrictClient:     data.RestrictClient,

--- a/service/handlers/sprofile.go
+++ b/service/handlers/sprofile.go
@@ -31,6 +31,7 @@ type sprofileData struct {
 	DeviceAuth         bool                        `json:"device_auth"`
 	DisableGateway     bool                        `json:"disable_gateway"`
 	DisableDns         bool                        `json:"disable_dns"`
+	DisableIpv6        bool                        `json:"disable_ipv6"`
 	Dco                bool                        `json:"dco"`
 	DebugOutput        bool                        `json:"debug_output"`
 	RestrictClient     bool                        `json:"restrict_client"`
@@ -127,6 +128,7 @@ func sprofilePut(c *gin.Context) {
 		DeviceAuth:         data.DeviceAuth,
 		DisableGateway:     data.DisableGateway,
 		DisableDns:         data.DisableDns,
+		DisableIpv6:        data.DisableIpv6,
 		Dco:                data.Dco,
 		DebugOutput:        data.DebugOutput,
 		RestrictClient:     data.RestrictClient,

--- a/service/parser/ovpn.go
+++ b/service/parser/ovpn.go
@@ -72,6 +72,7 @@ type Ovpn struct {
 
 	DisableGateway bool
 	DisableDns     bool
+	DisableIpv6    bool
 	Dco            bool
 }
 
@@ -182,6 +183,14 @@ func (o *Ovpn) Export(chown string) string {
 		output += "pull-filter ignore \"route-ipv6 2000::/3\"\n"
 	}
 
+	if o.DisableIpv6 {
+		output += "pull-filter ignore \"ifconfig-ipv6\"\n"
+		output += "pull-filter ignore \"route-ipv6\"\n"
+		output += "pull-filter ignore \"redirect-gateway ipv6\"\n"
+		output += "pull-filter ignore \"redirect-gateway-ipv6\"\n"
+		output += "pull-filter ignore \"tun-ipv6\"\n"
+	}
+
 	if o.DisableDns {
 		output += "pull-filter ignore \"dhcp-option\"\n"
 	}
@@ -234,11 +243,12 @@ func (o *Ovpn) Export(chown string) string {
 }
 
 func Import(data string, remotes []Remote,
-	disableGateway, disableDns, dco, debugOutput bool) (o *Ovpn) {
+	disableGateway, disableDns, disableIpv6, dco, debugOutput bool) (o *Ovpn) {
 
 	o = &Ovpn{
 		DisableGateway: disableGateway,
 		DisableDns:     disableDns,
+		DisableIpv6:    disableIpv6,
 		Dco:            dco,
 	}
 

--- a/service/sprofile/sprofile.go
+++ b/service/sprofile/sprofile.go
@@ -64,6 +64,7 @@ type Sprofile struct {
 	DeviceAuth         bool                        `json:"device_auth"`
 	DisableGateway     bool                        `json:"disable_gateway"`
 	DisableDns         bool                        `json:"disable_dns"`
+	DisableIpv6        bool                        `json:"disable_ipv6"`
 	Dco                bool                        `json:"dco"`
 	DebugOutput        bool                        `json:"debug_output"`
 	RestrictClient     bool                        `json:"restrict_client"`
@@ -108,6 +109,7 @@ type SprofileClient struct {
 	DeviceAuth         bool                        `json:"device_auth"`
 	DisableGateway     bool                        `json:"disable_Gateway"`
 	DisableDns         bool                        `json:"disable_dns"`
+	DisableIpv6        bool                        `json:"disable_ipv6"`
 	Dco                bool                        `json:"dco"`
 	DebugOutput        bool                        `json:"debug_output"`
 	RestrictClient     bool                        `json:"restrict_client"`
@@ -155,6 +157,7 @@ func (s *Sprofile) Client() (sprflc *SprofileClient) {
 		DeviceAuth:         s.DeviceAuth,
 		DisableGateway:     s.DisableGateway,
 		DisableDns:         s.DisableDns,
+		DisableIpv6:        s.DisableIpv6,
 		Dco:                s.Dco,
 		DebugOutput:        s.DebugOutput,
 		RestrictClient:     s.RestrictClient,
@@ -217,6 +220,7 @@ func (s *Sprofile) Copy() (sprfl *Sprofile) {
 		DeviceAuth:         s.DeviceAuth,
 		DisableGateway:     s.DisableGateway,
 		DisableDns:         s.DisableDns,
+		DisableIpv6:        s.DisableIpv6,
 		Dco:                s.Dco,
 		DebugOutput:        s.DebugOutput,
 		RestrictClient:     s.RestrictClient,
@@ -402,6 +406,7 @@ func (s *Sprofile) syncUpdate(data string) (updated bool, err error) {
 		s.DeviceAuth = confData.DeviceAuth
 		s.DisableGateway = confData.DisableGateway
 		s.DisableDns = confData.DisableDns
+		s.DisableIpv6 = confData.DisableIpv6
 		s.Dco = confData.Dco
 		s.DebugOutput = confData.DebugOutput
 		s.RestrictClient = confData.RestrictClient


### PR DESCRIPTION
### Problem

When a Pritunl server has IPv6 enabled (`server-ipv6`), it pushes `ifconfig-ipv6`, `route-ipv6` and `redirect-gateway ipv6` to every client. On hosts where the IPv6 stack is unavailable or cannot be configured — for example Windows hosts with `HKLM\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters\DisabledComponents=0xff` set, adapters with `ms_tcpip6` unbound, Linux with `net.ipv6.conf.all.disable_ipv6=1` or `ipv6.disable=1`, or minimal images/VMs built without IPv6 — the connection dies shortly after connecting:

1. openvpn receives the PUSH_REPLY and enters `do_ifconfig, ipv4=1, ipv6=1`
2. the IPv4 configuration succeeds
3. `netsh interface ipv6 set address` fails on the disabled stack, which is `M_FATAL` in openvpn (2.7.x, `msg_channel=0`), and the process exits (`ovpn_running=-1`)
4. the service marks the profile disconnected; with single sign-on profiles the automatic reconnect then fails with `client_auth_error` because re-authentication is not interactive

Reproduced on Windows 11 with client 1.3.4566.62 and openvpn 2.7.0. Profile log excerpt:

```
PUSH: Received control message: ... tun-ipv6, redirect-gateway ipv6 ...
  route-ipv6 2000::/3, ifconfig-ipv6 fd00:xxxx::.../64 fd00:xxxx::1 ...
do_ifconfig, ipv4=1, ipv6=1
IPv4 MTU set to 1500 on interface 13 using service
[process exits ~27s later applying the IPv6 interface address via netsh]
```

The result is that a client on such a host can never hold a connection to any server with `server-ipv6` enabled, even though an IPv4-only tunnel would work perfectly.

### Why users cannot work around it today

* Editing the `.ovpn` to add `pull-filter ignore "ifconfig-ipv6"` does not work: the service parser rebuilds the config on import and `pull-filter` is not an importable option, so the lines are dropped (`Configuration line filtered`).
* `disable_gateway` only ignores `redirect-gateway` and `route-ipv6 2000::/3`, not `ifconfig-ipv6`, and it also disables the IPv4 full tunnel.
* DCO makes no difference (same interface address configuration path).
* Re-enabling IPv6 on the host requires admin rights and is often not possible (the stack may be disabled intentionally, or not present at all).
* Disabling `server-ipv6` server side removes the `::/0` blackhole that prevents the dual stack IPv6 leak for all other (IPv6 capable) users of the server.

### Change

Adds a `disable_ipv6` profile option following the exact pattern of `disable_gateway` / `disable_dns`:

* `service/parser/ovpn.go`: `DisableIpv6` field; `Export()` emits `pull-filter ignore` for `ifconfig-ipv6`, `route-ipv6`, `redirect-gateway ipv6`, `redirect-gateway-ipv6` and `tun-ipv6`
* `service/connection/{profile,ovpn,state}.go`: carry the flag into the connection and the generated config
* `service/sprofile/sprofile.go`: struct fields, client/copy mappings and conf load, so system profiles support it via the conf file and `/sprofile`
* `service/handlers/{profile,sprofile}.go`: REST binding
* `cli/sprofile/sprofile.go`: struct field
* `client/app/types/ProfileTypes.ts`, `ProfileConnect.tsx`, `ProfileSettings.tsx`: "Disable IPv6" toggle in profile settings

With the option enabled the generated config contains the ignores next to the service's own pull-filters, openvpn completes `do_ifconfig` with ipv6=0 and the tunnel stays IPv4 only and stable on IPv6-disabled hosts.

Default is off; no behavior change for existing profiles.

### Testing

* `go build ./...` clean on `service/` and `cli/` (darwin/arm64 and windows/amd64 cross-compile)
* `tsc --noEmit` clean on `client/`
* Parser verified: `Import(..., disableIpv6=true).Export()` emits the five ignores in the generated config; with the option off none are emitted
